### PR TITLE
Using appropriate CGRect functions for accessing properties

### DIFF
--- a/FrameAccessor/ViewFrameAccessor.m
+++ b/FrameAccessor/ViewFrameAccessor.m
@@ -42,7 +42,7 @@
 
 - (CGFloat)x
 {
-    return self.frame.origin.x;
+    return CGRectGetMinX(self.frame);
 }
 
 - (void)setX:(CGFloat)newX
@@ -54,7 +54,7 @@
 
 - (CGFloat)y
 {
-    return self.frame.origin.y;
+    return CGRectGetMinY(self.frame);
 }
 
 - (void)setY:(CGFloat)newY
@@ -69,7 +69,7 @@
 
 - (CGFloat)height
 {
-    return self.frame.size.height;
+    return CGRectGetHeight(self.frame);
 }
 
 - (void)setHeight:(CGFloat)newHeight
@@ -81,7 +81,7 @@
 
 - (CGFloat)width
 {
-    return self.frame.size.width;
+    return CGRectGetWidth(self.frame);
 }
 
 - (void)setWidth:(CGFloat)newWidth
@@ -106,7 +106,7 @@
 
 - (CGFloat)right
 {
-    return self.frame.origin.x + self.frame.size.width;
+    return CGRectGetMaxX(self.frame);
 }
 
 - (void)setRight:(CGFloat)right
@@ -126,7 +126,7 @@
 
 - (CGFloat)bottom
 {
-    return self.frame.origin.y + self.frame.size.height;
+    return CGRectGetMaxY(self.frame);
 }
 
 - (void)setBottom:(CGFloat)bottom
@@ -180,12 +180,12 @@
 
 - (CGFloat)middleX
 {
-    return self.width / 2;
+    return CGRectGetMidX(self.bounds);
 }
 
 - (CGFloat)middleY
 {
-    return self.height / 2;
+    return CGRectGetMidY(self.bounds);
 }
 
 @end


### PR DESCRIPTION
Due to Apple advice it's better using functions to access CGRect properties rather than direct access

> The height and width stored in a CGRect data structure can be negative. For example, a rectangle with an origin of [0.0, 0.0] and a size of [10.0,10.0] is exactly equivalent to a rectangle with an origin of [10.0, 10.0] and a size of [-10.0,-10.0]. Your application can standardize a rectangle—that is, ensure that the height and width are stored as positive values—by calling the CGRectStandardize function. All functions described in this reference that take CGRect data structures as inputs implicitly standardize those rectangles before calculating their results. For this reason, your applications should avoid directly reading and writing the data stored in the CGRect data structure. Instead, use the functions described here to manipulate rectangles and to retrieve their characteristics.
